### PR TITLE
When comparing dicts for equality, convert to lists so that balance of trees doesn't make a difference

### DIFF
--- a/src/Sort/Dict.elm
+++ b/src/Sort/Dict.elm
@@ -80,15 +80,7 @@ empty sorter =
 -}
 eq : Dict k v -> Dict k v -> Bool
 eq first second =
-    case ( first, second ) of
-        ( Leaf _, Leaf _ ) ->
-            True
-
-        ( Node _ _ _ fValue fLeft fRight, Node _ _ _ sValue sLeft sRight ) ->
-            fValue == sValue && eq fLeft sLeft && eq fRight sRight
-
-        _ ->
-            False
+    toList first == toList second
 
 
 {-| Determine if a dictionary is empty.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -75,6 +75,18 @@ tests =
                 , test "get 2" <| \() -> Expect.equal Nothing (Dict.get "Spike" animals)
                 , test "size of empty dictionary" <| \() -> Expect.equal 0 (Dict.size (Dict.empty Sort.increasing))
                 , test "size of example dictionary" <| \() -> Expect.equal 2 (Dict.size animals)
+                , test "eq disregards order elements inserted" <| \() ->
+                    let
+                        elements =
+                            [1, 2, 3, 4] |> List.map (\i -> (i, ()))
+
+                        forward =
+                            Dict.fromList Sort.increasing elements
+
+                        backward =
+                            Dict.fromList Sort.increasing (List.reverse elements)
+                    in
+                    Expect.equal (Dict.eq forward backward) True
                 ]
 
         combineTests =


### PR DESCRIPTION
I noticed that `Sort.Dict.eq`/`Sort.Set.eq` return false for Dicts or Sets with the same elements but represented by differently balanced underlying trees.

Here is a small example with four-element sets (the smallest I could get to balance differently):
https://ellie-app.com/mtnzM9YXnsVa1

I think `eq` should use `toList` so that the balance of the underlying trees doesn't impact equality.